### PR TITLE
Workaround `pip` resolver issues

### DIFF
--- a/slurm/create-env.sh
+++ b/slurm/create-env.sh
@@ -15,8 +15,8 @@ mamba create -n $ENV -c rapidsai-nightly -c nvidia -c conda-forge \
 conda activate $ENV
 
 # use dask/distibuted latest
-python -m pip install git+https://github.com/dask/dask.git
-python -m pip install git+https://github.com/dask/distributed.git
+python -m pip install git+https://github.com/dask/dask.git@master
+python -m pip install git+https://github.com/dask/distributed.git@master
 
 cd /home/bzaitlen/GitRepos/dask-cuda
 python -m pip install .


### PR DESCRIPTION
Apparently specifying the branch (in this case `master`) works around some issue with `pip` trying to solve for dependencies. So make this change to get us past that issue.