### PR TITLE
Add conda-forge `compilers`

### DIFF
--- a/slurm/create-env.sh
+++ b/slurm/create-env.sh
@@ -8,7 +8,7 @@ source /gpfs/fs1/bzaitlen/miniconda3/bin/activate
 ENV=`date +"%Y%m%d-nightly-0.17"`
 
 mamba create -n $ENV -c rapidsai-nightly -c nvidia -c conda-forge \
-    automake make libtool pkg-config cudatoolkit=10.2 xarray \
+    automake make libtool pkg-config cudatoolkit=10.2 compilers xarray \
     libhwloc psutil python=3.8 setuptools cython matplotlib seaborn \
     cudf=0.17 dask-cudf ipython ipdb pygithub gprof2dot --yes --quiet
 

--- a/slurm/create-env.sh
+++ b/slurm/create-env.sh
@@ -9,7 +9,7 @@ ENV=`date +"%Y%m%d-nightly-0.17"`
 
 mamba create -n $ENV -c rapidsai-nightly -c nvidia -c conda-forge \
     automake make libtool pkg-config cudatoolkit=10.2 compilers xarray \
-    libhwloc psutil python=3.8 setuptools cython matplotlib seaborn \
+    libhwloc psutil python=3.8 setuptools pip cython matplotlib seaborn \
     cudf=0.17 dask-cudf ipython ipdb pygithub gprof2dot --yes --quiet
 
 conda activate $ENV


### PR DESCRIPTION
Uses conda-forge's `compilers` to perform the compilation. These also have a lot of useful flags baked in, which would be good to apply when compiling Cython-generated C code.