### PR TITLE
Install uvloop

### DIFF
--- a/slurm/create-env.sh
+++ b/slurm/create-env.sh
@@ -8,7 +8,7 @@ source /gpfs/fs1/bzaitlen/miniconda3/bin/activate
 ENV=`date +"%Y%m%d-nightly-0.18"`
 
 mamba create -n $ENV -c rapidsai-nightly -c nvidia -c conda-forge \
-    automake make libtool pkg-config cudatoolkit=10.2 xarray \
+    automake make libtool pkg-config cudatoolkit=10.2 xarray uvloop \
     libhwloc psutil python=3.8 setuptools pip cython matplotlib seaborn \
     cudf=0.18 dask-cudf dask-cuda ipython ipdb pygithub gprof2dot --yes --quiet
 


### PR DESCRIPTION
Now that Distributed supports uvloop, make sure that it is installed so that we can leverage it in benchmarks as needed.

xref: https://github.com/dask/distributed/pull/4448